### PR TITLE
expose more features for compat with musl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 cc = { version = "1.0.58", optional = true }
 
 [features]
-default = []
+default = [ "bindgen/runtime" ]
 bundled = [ "cc" ]
 
 # link libclang statically

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "euclio/hunspell-sys" }
 tempfile = "3.1.0"
 
 [build-dependencies]
-bindgen = "0.55.0"
+bindgen = "0.61.0"
 pkg-config = "0.3.17"
 cc = { version = "1.0.58", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hunspell-sys"
 description = "Bindings to the hunspell C API."
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Andy Russell <arussell123@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/euclio/hunspell-sys"
@@ -19,12 +19,15 @@ travis-ci = { repository = "euclio/hunspell-sys" }
 tempfile = "3.1.0"
 
 [build-dependencies]
-bindgen = "0.61.0"
+bindgen = { version = "0.61.0", default-features = false, features = ["logging", "which-rustfmt"]}
 pkg-config = "0.3.17"
 cc = { version = "1.0.58", optional = true }
 
 [features]
-
 default = []
+bundled = [ "cc" ]
 
-bundled = ["cc"]
+# link libclang statically
+static_libclang = [ "bindgen/static" ]
+# link system hunspell statically
+static = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hunspell-sys"
 description = "Bindings to the hunspell C API."
-version = "0.3.1"
+version = "0.3.0"
 authors = ["Andy Russell <arussell123@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/euclio/hunspell-sys"

--- a/README.md
+++ b/README.md
@@ -10,12 +10,22 @@ Rust bindings for the [hunspell] C API.
 
 ## Building
 
-By default `hunspell-sys` searches for a hunspell library installation with `pkg-config`.
+By default `hunspell-sys` searches for a hunspell library installation with `pkg-config`. By default the linkage is `dynamic`, if `static` is required use `static`
 
-Optionally, the bundled code of hunspell can be compiled with the `cc` crate.
-This behavior needs to activated by the `bundled` feature.
+Optionally, the bundled code of hunspell can be compiled with the `cc` crate and will be linked `static`ally when the `bundled` feature is present. The feature `static` is not required for this, the `bundled` feature will always link the produced hunspell artifact statically.
 
 ```toml
 [dependencies]
-hunspell-sys = { version = "0.2.1", features = ["bundled"] }
+hunspell-sys = { version = "0.3.1", features = ["bundled"] }
+```
+
+### musl targets
+
+If compiling for/on `musl` systems, `libclang` as used by `bindgen-rs`
+must be linked statically as well, which can be achieved with feature
+`static_libclang`.
+
+```toml
+[dependencies]
+hunspell-sys = { version = "0.3.1", features = ["bundled", "static_libclang"] }
 ```

--- a/build.rs
+++ b/build.rs
@@ -44,7 +44,10 @@ fn build_or_find_hunspell() -> Result<bindgen::Builder, Box<dyn Error>> {
 
 #[cfg(not(feature = "bundled"))]
 fn build_or_find_hunspell() -> Result<bindgen::Builder, Box<dyn Error>> {
-    pkg_config::probe_library("hunspell")?;
+    pkg_config::Config::new()
+        .atleast_version("1.7.0")
+        .statik(cfg!(feature = "static"))
+        .probe("hunspell")?;
 
     Ok(bindgen::Builder::default())
 }

--- a/build.rs
+++ b/build.rs
@@ -45,7 +45,7 @@ fn build_or_find_hunspell() -> Result<bindgen::Builder, Box<dyn Error>> {
 #[cfg(not(feature = "bundled"))]
 fn build_or_find_hunspell() -> Result<bindgen::Builder, Box<dyn Error>> {
     pkg_config::Config::new()
-        .atleast_version("1.7.0")
+        .atleast_version("1.0.0")
         .statik(cfg!(feature = "static"))
         .probe("hunspell")?;
 


### PR DESCRIPTION
When compiling on `musl`, bindgen needs to be compiled with the `static` feature flag. To make this feasible, expose a `static_libclang`.

```
thread 'main' panicked at 'Unable to find libclang: "the `libclang` shared library at /usr/lib/libclang.so.15.0.3 could not be opened: Dynamic loading not supported"
```